### PR TITLE
ScriptProperty

### DIFF
--- a/src/main/java/me/fengming/openjs/script/ScriptProperties.java
+++ b/src/main/java/me/fengming/openjs/script/ScriptProperties.java
@@ -33,7 +33,7 @@ public final class ScriptProperties {
         return Collections.unmodifiableMap(internal);
     }
 
-    public void initFromLines(List<String> lines) {
+    public void readFromLines(List<String> lines) {
         for (String line : lines) {
             line = line.trim();
             if (line.isEmpty()) {

--- a/src/main/java/me/fengming/openjs/script/ScriptProperties.java
+++ b/src/main/java/me/fengming/openjs/script/ScriptProperties.java
@@ -1,0 +1,57 @@
+package me.fengming.openjs.script;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author ZZZank
+ */
+public final class ScriptProperties {
+    /**
+     * TODO: make {@link ScriptProperty#ordinal} an {@code int}, then use Int2ObjectMap here
+     */
+    private final Map<Integer, Object> internal = new HashMap<>();
+
+    public <T> void put(ScriptProperty<T> property, T value) {
+        if (value != null) {
+            internal.put(property.ordinal, value);
+        }
+    }
+
+    public <T> T get(ScriptProperty<T> property) {
+        return (T) internal.get(property.ordinal);
+    }
+
+    public <T> T getOrDefault(ScriptProperty<T> property) {
+        var got = get(property);
+        return got == null ? property.defaultValue : got;
+    }
+
+    public Map<Integer, Object> getInternal() {
+        return Collections.unmodifiableMap(internal);
+    }
+
+    public void initFromLines(List<String> lines) {
+        for (String line : lines) {
+            line = line.trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+            if (!line.startsWith("//")) {
+                break;
+            }
+            line = line.substring("//".length()).trim();
+            var parts = line.split(":", 2);
+            if (parts.length < 2) {
+                continue;
+            }
+            var prop = ScriptProperty.get(parts[0].trim());
+            if (prop.isPresent()) {
+                var got = prop.get().read(parts[1].trim());
+                this.put((ScriptProperty<Object>) prop.get(), got);
+            }
+        }
+    }
+}

--- a/src/main/java/me/fengming/openjs/script/ScriptProperty.java
+++ b/src/main/java/me/fengming/openjs/script/ScriptProperty.java
@@ -1,0 +1,51 @@
+package me.fengming.openjs.script;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * @author ZZZank
+ */
+public final class ScriptProperty<T> {
+    private static final Map<String, ScriptProperty<?>> ALL = new HashMap<>();
+    private static int indexCurrent = 0;
+
+    public static final ScriptProperty<Integer> PRIORITY = register("priority", 0, Integer::valueOf);
+
+    public final String name;
+    public final Integer ordinal;
+    public final T defaultValue;
+    public final Function<String, @Nullable T> reader;
+
+    public static Optional<ScriptProperty<?>> get(String name) {
+        return Optional.ofNullable(ALL.get(name));
+    }
+
+    public static <T> ScriptProperty<T> register(String name, T defaultValue, Function<String, @Nullable T> reader) {
+        if (ALL.containsKey(name)) {
+            throw new IllegalArgumentException("script property with name '%s' already exists");
+        }
+        var prop = new ScriptProperty<>(name, indexCurrent++, defaultValue, reader);
+        ALL.put(name, prop);
+        return prop;
+    }
+
+    private ScriptProperty(String name, int ordinal, T defaultValue, Function<String, @Nullable T> reader) {
+        this.name = name;
+        this.ordinal = ordinal;
+        this.defaultValue = defaultValue;
+        this.reader = reader;
+    }
+
+    public T read(String raw) {
+        try {
+            return reader.apply(raw);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/me/fengming/openjs/script/ScriptProperty.java
+++ b/src/main/java/me/fengming/openjs/script/ScriptProperty.java
@@ -2,9 +2,7 @@ package me.fengming.openjs.script;
 
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 
 /**
@@ -15,6 +13,15 @@ public final class ScriptProperty<T> {
     private static int indexCurrent = 0;
 
     public static final ScriptProperty<Integer> PRIORITY = register("priority", 0, Integer::valueOf);
+    public static final ScriptProperty<List<String>> REQUIRE = register(
+        "require",
+        Collections.emptyList(),
+        (s) -> Arrays.stream(s.split(","))
+            .map(String::trim)
+            .filter(str -> !str.isEmpty())
+            .toList()
+    );
+    public static final ScriptProperty<Boolean> ENABLED = register("enabled", true, Boolean::valueOf);
 
     public final String name;
     public final Integer ordinal;


### PR DESCRIPTION
This PR:
- added `ScriptProperty` for storing script metadatas like `priority`, with basic registry system and some examples
- added getter methods for getting a script's priority and whether it should be enabled